### PR TITLE
master: rename to brigade-mongodb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,4 +1,4 @@
-name              'mongodb'
+name              'brigade-mongodb'
 maintainer        'edelight GmbH'
 maintainer_email  'markus.korn@edelight.de'
 license           'Apache 2.0'


### PR DESCRIPTION
Our attempts to claim the `mongodb` title in supermarket have been
unsuccessful. At this point, we're just keeping users from finding us by
continuing to pursue this goal.

So we're giving up on a seamless transition and using the most
reasonable name available to us
